### PR TITLE
use puppeteer instead of phantomjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Developer tools for Marko.
 
 # Installation
 
+**Requires Node 6+**
+
 Global installation:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -274,23 +274,6 @@ module.exports = function(markoCli) {
 }
 ```
 
-
-### Configuring PhantomJS
-
-You can configure PhantomJS for browser tests using `markoCli.config.phantomOptions`.
-[Supported `mocha-phantomjs-core` options](https://github.com/nathanboktae/mocha-phantomjs-core#config):
-
-_my-app/marko-cli.js:_
-
-```javascript
-module.exports = function(markoCli) {
-    markoCli.config.phantomOptions = {
-        timeout: 5000,
-        useColors: true
-    };
-}
-```
-
 ### Configuring Mocha
 
 You can easily configure Mocha for server-side tests using `markoCli.config.mochaOptions`.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "object-assign": "^4.1.0",
     "ora": "^1.2.0",
     "porti": "^1.0.2",
-    "puppeteer": "^0.10.1",
+    "puppeteer": "^0.10.2",
     "raptor-renderer": "^1.4.6",
     "resolve-from": "^2.0.0",
     "unzip": "^0.1.11"

--- a/package.json
+++ b/package.json
@@ -32,12 +32,10 @@
     "lasso-require": "^3.4.1",
     "mkdirp": "^0.5.1",
     "mocha": "^2",
-    "mocha-phantomjs-core": "^2.1.1",
-    "mocha-phantomjs-istanbul": "0.0.2",
     "object-assign": "^4.1.0",
     "ora": "^1.2.0",
-    "phantomjs-prebuilt": "^2.1.14",
     "porti": "^1.0.2",
+    "puppeteer": "^0.9.0",
     "raptor-renderer": "^1.4.6",
     "resolve-from": "^2.0.0",
     "unzip": "^0.1.11"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "object-assign": "^4.1.0",
     "ora": "^1.2.0",
     "porti": "^1.0.2",
-    "puppeteer": "^0.9.0",
+    "puppeteer": "^0.10.1",
     "raptor-renderer": "^1.4.6",
     "resolve-from": "^2.0.0",
     "unzip": "^0.1.11"

--- a/src/commands/test/util/browser-tests-runner/mocha-run.js
+++ b/src/commands/test/util/browser-tests-runner/mocha-run.js
@@ -1,1 +1,14 @@
-window.mocha.run();
+const runner = window.mocha.run()
+
+let success = true
+
+runner.once('fail', () => {
+    success = false
+});
+
+runner.on('end', async (event) => {
+    console.log('result:', {
+        success,
+        coverage: window.__coverage__
+    });
+});

--- a/src/commands/test/util/browser-tests-runner/mocha-run.js
+++ b/src/commands/test/util/browser-tests-runner/mocha-run.js
@@ -1,9 +1,9 @@
 const runner = window.mocha.run()
 
-let success = true
+let success = true;
 
 runner.once('fail', () => {
-    success = false
+    success = false;
 });
 
 runner.on('end', (event) => {

--- a/src/commands/test/util/browser-tests-runner/mocha-run.js
+++ b/src/commands/test/util/browser-tests-runner/mocha-run.js
@@ -6,7 +6,7 @@ runner.once('fail', () => {
     success = false
 });
 
-runner.on('end', async (event) => {
+runner.on('end', (event) => {
     console.log('result:', {
         success,
         coverage: window.__coverage__

--- a/src/commands/test/util/browser-tests-runner/setup.js
+++ b/src/commands/test/util/browser-tests-runner/setup.js
@@ -1,11 +1,13 @@
 var BrowserContext = require('./BrowserContext');
 
-if (window.initMochaPhantomJS === 'function') {
-    window.initMochaPhantomJS();
+if (window.location.hash === '#headless') {
+    window.mocha.reporter('spec');
+    window.mocha.useColors('true');
+} else {
+    window.mocha.reporter('html');
 }
 
 window.mocha.ui('bdd');
-window.mocha.reporter('html');
 
 require('chai').config.includeStack = true;
 

--- a/src/commands/test/util/browser-tests-runner/setup.js
+++ b/src/commands/test/util/browser-tests-runner/setup.js
@@ -1,13 +1,21 @@
 var BrowserContext = require('./BrowserContext');
+var options = {};
 
-if (window.location.hash === '#headless') {
-    window.mocha.reporter('spec');
-    window.mocha.useColors('true');
-} else {
-    window.mocha.reporter('html');
+if (window.location.search) {
+    try {
+        options = JSON.parse(decodeURIComponent(window.location.search.slice(1)))
+    } catch(e) {
+        console.error(e);
+    }
 }
 
-window.mocha.ui('bdd');
+var mochaOptions = Object.assign({ reporter:'html', ui:'bdd' }, options.mocha);
+
+Object.keys(mochaOptions).forEach(function(key) {
+    if (typeof window.mocha[key] === 'function') {
+        window.mocha[key](mochaOptions[key]);
+    }
+});
 
 require('chai').config.includeStack = true;
 


### PR DESCRIPTION
Several months ago the maintainer of PhantomJS is [announced he'd be stepping down from the project](https://groups.google.com/forum/#!topic/phantomjs/9aI5d-LDuNE). 

Last week the chrome team unveiled [puppeteer](https://github.com/GoogleChrome/puppeteer): a headless chrome api for node.  One big benefit of puppeteer is that it ships with its [own version of chromium that is guaranteed to work with the API](https://github.com/GoogleChrome/puppeteer#default-runtime-settings).

<s>It does, however, require node 7.x+ as it uses `async`/`await`</s>
`puppeteer@0.10` supports node 6!

**TODO:**
- [x] update the docs to remove references to phantomjs