### PR TITLE
add missing require-self-ref dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "marko": "bin/marko"
   },
   "devDependencies": {
-    "ava": "^0.22.0"
+    "ava": "^0.22.0",
+    "require-self-ref": "^2.0.1"
   }
 }


### PR DESCRIPTION
`require-self-ref` is used in the tests, but not listed in `package.json`. I added it as a `devDependency`.

https://github.com/marko-js/marko-cli/blob/245b9bbacbf2c8920faae0e757137eb357102a9f/src/util/hasMarkoCliInstalled.test.js#L1