### PR TITLE
Show usage in case no command is passed

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -11,7 +11,12 @@ exports.run = function(argv) {
     var commandName = argv[2];
 
     if (!markoDevTools.hasCommand(commandName)) {
-        console.error('Invalid command: ' + commandName);
+        if (commandName === undefined){
+            console.error('Usage: marko <command> arg0 arg1 ... argn')
+        }
+        else {
+            console.error('Invalid command: ' + commandName);
+        }
         console.error('Allowed commands: ' +markoDevTools.commands.getNames().join(' '));
         process.exit(1);
     }


### PR DESCRIPTION
Using the command without arguments
```sh
$ marko
```
 
Before:
```
Invalid command: undefined
Allowed commands: test create compile
```

Now
```
Usage: marko <command> arg0 arg1 ... argn
Allowed commands: test create compile
```