### PR TITLE
add puppeteer options

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,20 @@ module.exports = function(markoCli) {
 }
 ```
 
+### Configuring Puppeteer
+You can configure Puppeteer using `markoCli.config.puppeteerOptions`, which will be passed through `puppeteer.launch()`.
+Supported options can be found in the [Puppeteer documentation](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions).
+
+_my-app/marko-cli.js:_
+
+```javascript
+module.exports = function(markoCli) {
+    markoCli.config.puppeteerOptions = {
+        headless: false
+    };
+}
+```
+
 # TODO
 
 - Don't write compiled templates to disk

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@marko/compile": "^1.0.0",
     "@marko/create": "^1.0.0",
-    "@marko/test": "^1.0.1",
+    "@marko/test": "^1.0.5",
     "app-root-dir": "^1.0.2",
     "argly": "^1.0.0",
     "chalk": "^1.1.3",

--- a/src/commands/test/run.js
+++ b/src/commands/test/run.js
@@ -5,6 +5,7 @@ const markoTest = require('@marko/test');
 module.exports = function run(options, markoCli) {
   const {
     mochaOptions,
+    puppeteerOptions,
     testMatcher,
     browserBuilder,
     workDir,
@@ -13,6 +14,7 @@ module.exports = function run(options, markoCli) {
 
   return markoTest.run(Object.assign({
     mochaOptions,
+    puppeteerOptions,
     testMatcher,
     browserBuilder,
     workDir,


### PR DESCRIPTION
Follow up PR to https://github.com/marko-js/marko-util/pull/8

Allows passing `puppeteerOptions` to `@marko/test` when launching Puppeteer.