### PR TITLE
Removing RenderResult.html in favor of RenderResult.toString()

### DIFF
--- a/packages/prebuild/package-lock.json
+++ b/packages/prebuild/package-lock.json
@@ -7,53 +7,53 @@
       "resolved": "https://registry.npmjs.org/lasso/-/lasso-3.0.1-0.tgz",
       "integrity": "sha512-8Klxfalyy+NFHzi6bgzMZXRVSpPKu6vPe+1ZY0CS9SkyryKwbbK20APEUQMrnLVsJ3W5do5lPqzTiHg0ZgGp2A==",
       "requires": {
-        "app-module-path": "^1.1.0",
-        "app-root-dir": "^1.0.2",
-        "assert": "^1.1.2",
-        "async": "^0.9.2",
-        "browser-refresh-client": "^1.1.4",
-        "buffer": "^4.5.1",
-        "clean-css": "^3.4.28",
-        "clone": "^0.1.19",
-        "complain": "^1.2.0",
-        "escodegen": "^1.6.0",
-        "esprima": "^4.0.0",
-        "estraverse": "^4.2.0",
-        "events": "^1.0.2",
-        "glob": "^7.1.1",
-        "image-size": "^0.6.1",
-        "lasso-caching-fs": "^1.0.2",
-        "lasso-loader": "^3.0.2",
-        "lasso-modules-client": "^2.0.5",
-        "lasso-package-root": "^1.0.1",
-        "lasso-resolve-from": "^1.2.0",
-        "marko": "^4.2.8",
-        "mime": "^1.2.11",
-        "mkdirp": "^0.5.1",
+        "app-module-path": "1.1.0",
+        "app-root-dir": "1.0.2",
+        "assert": "1.4.1",
+        "async": "0.9.2",
+        "browser-refresh-client": "1.1.4",
+        "buffer": "4.9.1",
+        "clean-css": "3.4.28",
+        "clone": "0.1.19",
+        "complain": "1.2.0",
+        "escodegen": "1.9.1",
+        "esprima": "4.0.0",
+        "estraverse": "4.2.0",
+        "events": "1.1.1",
+        "glob": "7.1.2",
+        "image-size": "0.6.2",
+        "lasso-caching-fs": "1.0.2",
+        "lasso-loader": "3.0.2",
+        "lasso-modules-client": "2.0.5",
+        "lasso-package-root": "1.0.1",
+        "lasso-resolve-from": "1.2.0",
+        "marko": "4.9.7",
+        "mime": "1.6.0",
+        "mkdirp": "0.5.1",
         "path-browserify": "0.0.0",
-        "pify": "^3.0.0",
-        "process": "^0.6.0",
-        "property-handlers": "^1.1.1",
-        "raptor-async": "^1.1.3",
-        "raptor-cache": "^2.0.0",
-        "raptor-css-parser": "^1.1.5",
-        "raptor-detect": "^1.0.1",
-        "raptor-logging": "^1.1.2",
-        "raptor-objects": "^1.0.2",
-        "raptor-polyfill": "^1.0.2",
-        "raptor-promises": "^1.0.3",
-        "raptor-regexp": "^1.0.1",
-        "raptor-strings": "^1.0.2",
-        "raptor-util": "^3.2.0",
-        "resolve-from": "^1.0.1",
-        "send": "^0.13.2",
-        "stream-browserify": "^1.0.0",
-        "string_decoder": "^0.10.31",
-        "strip-json-comments": "^2.0.1",
-        "through": "^2.3.8",
-        "uglify-js": "^2.8.29",
-        "url": "^0.11.0",
-        "util": "^0.10.3"
+        "pify": "3.0.0",
+        "process": "0.6.0",
+        "property-handlers": "1.1.1",
+        "raptor-async": "1.1.3",
+        "raptor-cache": "2.0.3",
+        "raptor-css-parser": "1.1.5",
+        "raptor-detect": "1.0.1",
+        "raptor-logging": "1.1.3",
+        "raptor-objects": "1.0.2",
+        "raptor-polyfill": "1.0.2",
+        "raptor-promises": "1.0.3",
+        "raptor-regexp": "1.0.1",
+        "raptor-strings": "1.0.2",
+        "raptor-util": "3.2.0",
+        "resolve-from": "1.0.1",
+        "send": "0.13.2",
+        "stream-browserify": "1.0.0",
+        "string_decoder": "0.10.31",
+        "strip-json-comments": "2.0.1",
+        "through": "2.3.8",
+        "uglify-js": "2.8.29",
+        "url": "0.11.0",
+        "util": "0.10.3"
       },
       "dependencies": {
         "align-text": {
@@ -61,9 +61,9 @@
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "requires": {
-            "kind-of": "^3.0.2",
-            "longest": "^1.0.1",
-            "repeat-string": "^1.5.2"
+            "kind-of": "3.2.2",
+            "longest": "1.0.1",
+            "repeat-string": "1.6.1"
           }
         },
         "amdefine": {
@@ -119,7 +119,7 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-0.7.0.tgz",
           "integrity": "sha1-P7BnBgKsKHjrdw3CA58YNr5irls=",
           "requires": {
-            "readable-stream": "~1.0.2"
+            "readable-stream": "1.0.34"
           },
           "dependencies": {
             "isarray": {
@@ -132,10 +132,10 @@
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
               }
             }
           }
@@ -145,7 +145,7 @@
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -159,9 +159,9 @@
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4",
-            "isarray": "^1.0.0"
+            "base64-js": "1.3.0",
+            "ieee754": "1.1.11",
+            "isarray": "1.0.0"
           }
         },
         "camelcase": {
@@ -174,8 +174,8 @@
           "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
           "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
           "requires": {
-            "align-text": "^0.1.3",
-            "lazy-cache": "^1.0.3"
+            "align-text": "0.1.4",
+            "lazy-cache": "1.0.4"
           }
         },
         "chai": {
@@ -183,9 +183,9 @@
           "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
           "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
           "requires": {
-            "assertion-error": "^1.0.1",
-            "deep-eql": "^0.1.3",
-            "type-detect": "^1.0.0"
+            "assertion-error": "1.1.0",
+            "deep-eql": "0.1.3",
+            "type-detect": "1.0.0"
           }
         },
         "char-props": {
@@ -198,8 +198,8 @@
           "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.28.tgz",
           "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
           "requires": {
-            "commander": "2.8.x",
-            "source-map": "0.4.x"
+            "commander": "2.8.1",
+            "source-map": "0.4.4"
           }
         },
         "cliui": {
@@ -207,8 +207,8 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
             "wordwrap": "0.0.2"
           },
           "dependencies": {
@@ -229,7 +229,7 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "requires": {
-            "graceful-readlink": ">= 1.0.0"
+            "graceful-readlink": "1.0.1"
           }
         },
         "complain": {
@@ -237,7 +237,7 @@
           "resolved": "https://registry.npmjs.org/complain/-/complain-1.2.0.tgz",
           "integrity": "sha512-aP/MxFoYYVUZ8Xdih1vyaTSRiD99XLnlCloNre/UjFQFJkZ6YuMbGksi0jfxKeFOdlzm/6eE01vpJc99HiN/Mg==",
           "requires": {
-            "error-stack-parser": "^2.0.1"
+            "error-stack-parser": "2.0.1"
           }
         },
         "concat-map": {
@@ -293,9 +293,9 @@
           "resolved": "https://registry.npmjs.org/deresolve/-/deresolve-1.1.2.tgz",
           "integrity": "sha1-nPI3nI0tYx3EuZVylLkOSnLLbOA=",
           "requires": {
-            "lasso-package-root": "^1.0.0",
-            "raptor-polyfill": "^1.0.2",
-            "resolve-from": "^1.0.1"
+            "lasso-package-root": "1.0.1",
+            "raptor-polyfill": "1.0.2",
+            "resolve-from": "1.0.1"
           }
         },
         "destroy": {
@@ -308,8 +308,8 @@
           "resolved": "https://registry.npmjs.org/dissolve/-/dissolve-0.3.3.tgz",
           "integrity": "sha1-uX7x/ymJx4nOz7AxB+F0EfqL5uU=",
           "requires": {
-            "bl": "^0.7.0",
-            "readable-stream": "^1.0.26"
+            "bl": "0.7.0",
+            "readable-stream": "1.1.14"
           }
         },
         "ee-first": {
@@ -322,7 +322,7 @@
           "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.1.tgz",
           "integrity": "sha1-oyArj7AxFKqbQKDjZp5IsrZaAQo=",
           "requires": {
-            "stackframe": "^1.0.3"
+            "stackframe": "1.0.4"
           }
         },
         "escape-html": {
@@ -335,11 +335,11 @@
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
           "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
           "requires": {
-            "esprima": "^3.1.3",
-            "estraverse": "^4.2.0",
-            "esutils": "^2.0.2",
-            "optionator": "^0.8.1",
-            "source-map": "~0.6.1"
+            "esprima": "3.1.3",
+            "estraverse": "4.2.0",
+            "esutils": "2.0.2",
+            "optionator": "0.8.2",
+            "source-map": "0.6.1"
           },
           "dependencies": {
             "esprima": {
@@ -385,7 +385,7 @@
           "resolved": "https://registry.npmjs.org/events-light/-/events-light-1.0.5.tgz",
           "integrity": "sha1-lk5jRQugr0prAiqpVbF//vZXte4=",
           "requires": {
-            "chai": "^3.5.0"
+            "chai": "3.5.0"
           }
         },
         "fast-levenshtein": {
@@ -408,12 +408,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.1",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "graceful-readlink": {
@@ -431,8 +431,8 @@
           "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-2.3.2.tgz",
           "integrity": "sha1-HMW/mCSgkcKIILM+r3gIOo6qhWw=",
           "requires": {
-            "char-props": "^0.1.5",
-            "complain": "^1.0.0"
+            "char-props": "0.1.5",
+            "complain": "1.2.0"
           }
         },
         "http-errors": {
@@ -440,8 +440,8 @@
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
           "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
           "requires": {
-            "inherits": "~2.0.1",
-            "statuses": "1"
+            "inherits": "2.0.1",
+            "statuses": "1.2.1"
           }
         },
         "ieee754": {
@@ -459,8 +459,8 @@
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -473,8 +473,8 @@
           "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
           "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
           "requires": {
-            "is-relative": "^0.2.1",
-            "is-windows": "^0.2.0"
+            "is-relative": "0.2.1",
+            "is-windows": "0.2.0"
           }
         },
         "is-buffer": {
@@ -487,7 +487,7 @@
           "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
           "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
           "requires": {
-            "is-unc-path": "^0.1.1"
+            "is-unc-path": "0.1.2"
           }
         },
         "is-unc-path": {
@@ -495,7 +495,7 @@
           "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
           "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
           "requires": {
-            "unc-path-regex": "^0.1.0"
+            "unc-path-regex": "0.1.2"
           }
         },
         "is-windows": {
@@ -513,7 +513,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "lasso-caching-fs": {
@@ -521,7 +521,7 @@
           "resolved": "https://registry.npmjs.org/lasso-caching-fs/-/lasso-caching-fs-1.0.2.tgz",
           "integrity": "sha1-m+TrHwaqwSYDRMrq70LC8AhusQ0=",
           "requires": {
-            "raptor-async": "^1.1.2"
+            "raptor-async": "1.1.3"
           }
         },
         "lasso-loader": {
@@ -529,8 +529,8 @@
           "resolved": "https://registry.npmjs.org/lasso-loader/-/lasso-loader-3.0.2.tgz",
           "integrity": "sha1-29tV1fcu6zpbrnSn4xtrtf8t0JM=",
           "requires": {
-            "events": "^1.0.2",
-            "raptor-util": "^1.0.0"
+            "events": "1.1.1",
+            "raptor-util": "1.1.2"
           },
           "dependencies": {
             "raptor-util": {
@@ -545,8 +545,8 @@
           "resolved": "https://registry.npmjs.org/lasso-modules-client/-/lasso-modules-client-2.0.5.tgz",
           "integrity": "sha1-2aBnJKkAl3Y2lxZn7pwXDS/E3Sg=",
           "requires": {
-            "lasso-package-root": "^1.0.0",
-            "raptor-polyfill": "^1.0.2"
+            "lasso-package-root": "1.0.1",
+            "raptor-polyfill": "1.0.2"
           }
         },
         "lasso-package-root": {
@@ -554,7 +554,7 @@
           "resolved": "https://registry.npmjs.org/lasso-package-root/-/lasso-package-root-1.0.1.tgz",
           "integrity": "sha1-mX0OcfQdA8Xw+gmlvCmNeW+LLCM=",
           "requires": {
-            "lasso-caching-fs": "^1.0.0"
+            "lasso-caching-fs": "1.0.2"
           }
         },
         "lasso-resolve-from": {
@@ -562,10 +562,10 @@
           "resolved": "https://registry.npmjs.org/lasso-resolve-from/-/lasso-resolve-from-1.2.0.tgz",
           "integrity": "sha1-v7I0Rnr7abUwn1aLpFnMgyBiHG4=",
           "requires": {
-            "is-absolute": "^0.2.3",
-            "lasso-caching-fs": "^1.0.1",
-            "raptor-util": "^1.0.10",
-            "resolve-from": "^2.0.0"
+            "is-absolute": "0.2.6",
+            "lasso-caching-fs": "1.0.2",
+            "raptor-util": "1.1.2",
+            "resolve-from": "2.0.0"
           },
           "dependencies": {
             "raptor-util": {
@@ -590,8 +590,8 @@
           "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
           "requires": {
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2"
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2"
           }
         },
         "listener-tracker": {
@@ -609,37 +609,37 @@
           "resolved": "https://registry.npmjs.org/marko/-/marko-4.9.7.tgz",
           "integrity": "sha512-rgfTrPC3KTnh6AV0kU1BYZ2PCIzFlcK3jYqGKwD2JdcLXce+tJThP39BZ2Uqkzn6sGwbGYSE2SoasPnALa3EJA==",
           "requires": {
-            "app-module-path": "^2.2.0",
-            "argly": "^1.0.0",
-            "browser-refresh-client": "^1.0.0",
-            "char-props": "~0.1.5",
-            "complain": "^1.2.0",
-            "deresolve": "^1.1.2",
-            "escodegen": "^1.8.1",
-            "esprima": "^4.0.0",
-            "estraverse": "^4.2.0",
-            "events": "^1.0.2",
-            "events-light": "^1.0.0",
-            "he": "^1.1.0",
-            "htmljs-parser": "^2.3.2",
-            "lasso-caching-fs": "^1.0.1",
-            "lasso-modules-client": "^2.0.4",
-            "lasso-package-root": "^1.0.1",
-            "listener-tracker": "^2.0.0",
-            "minimatch": "^3.0.2",
-            "object-assign": "^4.1.0",
-            "property-handlers": "^1.0.0",
-            "raptor-json": "^1.0.1",
-            "raptor-polyfill": "^1.0.0",
-            "raptor-promises": "^1.0.1",
-            "raptor-regexp": "^1.0.0",
-            "raptor-util": "^3.2.0",
-            "resolve-from": "^2.0.0",
+            "app-module-path": "2.2.0",
+            "argly": "1.2.0",
+            "browser-refresh-client": "1.1.4",
+            "char-props": "0.1.5",
+            "complain": "1.2.0",
+            "deresolve": "1.1.2",
+            "escodegen": "1.9.1",
+            "esprima": "4.0.0",
+            "estraverse": "4.2.0",
+            "events": "1.1.1",
+            "events-light": "1.0.5",
+            "he": "1.1.1",
+            "htmljs-parser": "2.3.2",
+            "lasso-caching-fs": "1.0.2",
+            "lasso-modules-client": "2.0.5",
+            "lasso-package-root": "1.0.1",
+            "listener-tracker": "2.0.0",
+            "minimatch": "3.0.4",
+            "object-assign": "4.1.1",
+            "property-handlers": "1.1.1",
+            "raptor-json": "1.1.0",
+            "raptor-polyfill": "1.0.2",
+            "raptor-promises": "1.0.3",
+            "raptor-regexp": "1.0.1",
+            "raptor-util": "3.2.0",
+            "resolve-from": "2.0.0",
             "shorthash": "0.0.2",
-            "simple-sha1": "^2.1.0",
-            "strip-json-comments": "^2.0.1",
-            "try-require": "^1.2.1",
-            "warp10": "^1.0.0"
+            "simple-sha1": "2.1.0",
+            "strip-json-comments": "2.0.1",
+            "try-require": "1.2.1",
+            "warp10": "1.3.6"
           },
           "dependencies": {
             "app-module-path": {
@@ -664,7 +664,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -703,7 +703,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "optionator": {
@@ -711,12 +711,12 @@
           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
           "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
           "requires": {
-            "deep-is": "~0.1.3",
-            "fast-levenshtein": "~2.0.4",
-            "levn": "~0.3.0",
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2",
-            "wordwrap": "~1.0.0"
+            "deep-is": "0.1.3",
+            "fast-levenshtein": "2.0.6",
+            "levn": "0.3.0",
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2",
+            "wordwrap": "1.0.0"
           }
         },
         "path-browserify": {
@@ -779,14 +779,14 @@
           "resolved": "https://registry.npmjs.org/raptor-cache/-/raptor-cache-2.0.3.tgz",
           "integrity": "sha512-u32yJa0+is8KSPt4U/4mxoycy6rlpsWKFDka9LUctuuJLzveVxN4RjYtg32WveI2bNrnmPyLO70fMgyDuzOEEw==",
           "requires": {
-            "dissolve": "^0.3.3",
-            "mkdirp": "^0.5.0",
-            "property-handlers": "^1.0.0",
-            "raptor-async": "^1.0.0",
-            "raptor-logging": "^1.0.1",
-            "raptor-util": "^1.0.0",
-            "through": "^2.3.4",
-            "uuid": "^3.0.0"
+            "dissolve": "0.3.3",
+            "mkdirp": "0.5.1",
+            "property-handlers": "1.1.1",
+            "raptor-async": "1.1.3",
+            "raptor-logging": "1.1.3",
+            "raptor-util": "1.1.2",
+            "through": "2.3.8",
+            "uuid": "3.2.1"
           },
           "dependencies": {
             "raptor-util": {
@@ -801,8 +801,8 @@
           "resolved": "https://registry.npmjs.org/raptor-css-parser/-/raptor-css-parser-1.1.5.tgz",
           "integrity": "sha1-HeAY2WEhyNwfHDRoZUmv9xZJ0Dc=",
           "requires": {
-            "raptor-async": "^1.0.0",
-            "raptor-promises": "^1.0.1"
+            "raptor-async": "1.1.3",
+            "raptor-promises": "1.0.3"
           }
         },
         "raptor-detect": {
@@ -815,7 +815,7 @@
           "resolved": "https://registry.npmjs.org/raptor-json/-/raptor-json-1.1.0.tgz",
           "integrity": "sha1-cL0JsU5k99MuxQzOg3fWApwPCHY=",
           "requires": {
-            "raptor-strings": "^1.0.0"
+            "raptor-strings": "1.0.2"
           }
         },
         "raptor-logging": {
@@ -823,8 +823,8 @@
           "resolved": "https://registry.npmjs.org/raptor-logging/-/raptor-logging-1.1.3.tgz",
           "integrity": "sha512-eklLyQmG5Y2oyIrSsvkFjBkjRYvwjemUQpQhjG757KKaNPxIPX9wu34bfQkIcS7OG495CP28CjX9baABLfOzIw==",
           "requires": {
-            "raptor-polyfill": "^1.0.0",
-            "raptor-stacktraces": "^1.0.0"
+            "raptor-polyfill": "1.0.2",
+            "raptor-stacktraces": "1.0.1"
           }
         },
         "raptor-objects": {
@@ -832,7 +832,7 @@
           "resolved": "https://registry.npmjs.org/raptor-objects/-/raptor-objects-1.0.2.tgz",
           "integrity": "sha1-mQ3ONgQTsHni5K8RTy5zRKcc7hE=",
           "requires": {
-            "raptor-util": "^1.0.0"
+            "raptor-util": "1.1.2"
           },
           "dependencies": {
             "raptor-util": {
@@ -852,8 +852,8 @@
           "resolved": "https://registry.npmjs.org/raptor-promises/-/raptor-promises-1.0.3.tgz",
           "integrity": "sha1-1XaxEOBCNlT3/fFyHijULk3DwOs=",
           "requires": {
-            "q": "^1.0.1",
-            "raptor-util": "^1.0.0"
+            "q": "1.5.1",
+            "raptor-util": "1.1.2"
           },
           "dependencies": {
             "raptor-util": {
@@ -878,7 +878,7 @@
           "resolved": "https://registry.npmjs.org/raptor-strings/-/raptor-strings-1.0.2.tgz",
           "integrity": "sha1-ks4ssBU6/pBHDYA5oCVbTPM6tfw=",
           "requires": {
-            "raptor-polyfill": "^1.0.1"
+            "raptor-polyfill": "1.0.2"
           }
         },
         "raptor-util": {
@@ -891,10 +891,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           },
           "dependencies": {
             "isarray": {
@@ -919,7 +919,7 @@
           "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
           "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
           "requires": {
-            "align-text": "^0.1.1"
+            "align-text": "0.1.4"
           }
         },
         "rusha": {
@@ -932,18 +932,18 @@
           "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
           "integrity": "sha1-dl52B8gFVFK7pvCwUllTUJhgNt4=",
           "requires": {
-            "debug": "~2.2.0",
-            "depd": "~1.1.0",
-            "destroy": "~1.0.4",
-            "escape-html": "~1.0.3",
-            "etag": "~1.7.0",
+            "debug": "2.2.0",
+            "depd": "1.1.2",
+            "destroy": "1.0.4",
+            "escape-html": "1.0.3",
+            "etag": "1.7.0",
             "fresh": "0.3.0",
-            "http-errors": "~1.3.1",
+            "http-errors": "1.3.1",
             "mime": "1.3.4",
             "ms": "0.7.1",
-            "on-finished": "~2.3.0",
-            "range-parser": "~1.0.3",
-            "statuses": "~1.2.1"
+            "on-finished": "2.3.0",
+            "range-parser": "1.0.3",
+            "statuses": "1.2.1"
           },
           "dependencies": {
             "mime": {
@@ -963,7 +963,7 @@
           "resolved": "https://registry.npmjs.org/simple-sha1/-/simple-sha1-2.1.0.tgz",
           "integrity": "sha1-lCe7lv8SY8wQqEFM7dUaGLkZ6LM=",
           "requires": {
-            "rusha": "^0.8.1"
+            "rusha": "0.8.13"
           }
         },
         "source-map": {
@@ -971,7 +971,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         },
         "stackframe": {
@@ -989,8 +989,8 @@
           "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
           "integrity": "sha1-v5tKv7QrJ011FHnkTg/yZWtvEZM=",
           "requires": {
-            "inherits": "~2.0.1",
-            "readable-stream": "^1.0.27-1"
+            "inherits": "2.0.1",
+            "readable-stream": "1.1.14"
           }
         },
         "string_decoder": {
@@ -1018,7 +1018,7 @@
           "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
           "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
           "requires": {
-            "prelude-ls": "~1.1.2"
+            "prelude-ls": "1.1.2"
           }
         },
         "type-detect": {
@@ -1031,9 +1031,9 @@
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "requires": {
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
           },
           "dependencies": {
             "source-map": {
@@ -1101,9 +1101,9 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
             "window-size": "0.1.0"
           }
         }

--- a/packages/test/src/util/browser-tests-runner/browser-dependencies/browser-context.js
+++ b/packages/test/src/util/browser-tests-runner/browser-dependencies/browser-context.js
@@ -31,29 +31,8 @@ class BrowserContext {
       // component exposes renderer function
       renderResult = raptorRenderer.render(component.renderer, data);
     } else if (component.renderSync) {
-      // potentially a v4 or v3 component
+      // potentially a v4 or v3 component.
       renderResult = component.renderSync(data);
-      if (!renderResult.html) {
-        // this is a v4 component
-        const output = renderResult.getOutput();
-        let html;
-
-        if (output.actualize) {
-          // generate html from childNodes
-          const fragment = output.actualize(document);
-          html = "";
-
-          if (fragment.hasChildNodes()) {
-            for (const child of fragment.childNodes) {
-              html += child.outerHTML;
-            }
-          }
-        } else {
-          html = output.toString();
-        }
-
-        renderResult.html = html;
-      }
     } else {
       // assume older version of marko
       renderResult = component.render(data);
@@ -74,7 +53,7 @@ class BrowserContext {
 class WrappedRenderResult {
   constructor(renderResult, context) {
     this._renderResult = renderResult;
-    this.html = renderResult.html;
+    this.html = renderResult.toString();
     this._$ = null;
     this._widget = null;
     this.context = context;


### PR DESCRIPTION
Copy of PR https://github.com/marko-js/marko-cli/pull/83 but with package-lock.json updated.

Marko v4 does not support RenderResult.html, but both v4 and v3 support RenderResult.toString().

This fixes browser rendering in tests for Marko v4.