### PR TITLE
Misc fixes / improvements to the test command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,21 +84,28 @@ Run only server tests:
 marko test ./src/components/**/test*server.js --server
 ```
 
+All node options are forwarded to the mocha process for server testing, allowing the following:
+
+```bash
+# Will start a debugging session on the spawned mocha process.
+marko test --server --inspect-brk
+```
+
 # Component testing
 
 Marko CLI includes a testing framework (built on top of [mocha](https://mochajs.org/)) that targets UI components built using Marko or Marko Widgets. Each UI
 component may include test files alongside components or in a `test/` directory that consists of one or more JavaScript test files with a name in any of the
 following formats:
 
-* `test.js` - runs only in the browser
-* `test.server.js` _or_ `test-server.js` - runs only on the server
-* `test.browser.js` _or_ `test-browser.js` - runs only in the browser
+- `test.js` - runs only in the browser
+- `test.server.js` _or_ `test-server.js` - runs only on the server
+- `test.browser.js` _or_ `test-browser.js` - runs only in the browser
 
 An optional prefix can also be provided for grouping tests:
 
-* `foo.test.js` _or_ `foo-test.js`
-* `foo.test.server.js` _or_ `foo-test-server.js`
-* `foo.test.browser.js` _or_ `foo-test-browser.js`
+- `foo.test.js` _or_ `foo-test.js`
+- `foo.test.server.js` _or_ `foo-test-server.js`
+- `foo.test.browser.js` _or_ `foo-test-browser.js`
 
 Below is a sample set of tests:
 
@@ -308,7 +315,8 @@ module.exports = function(markoCli) {
          */
         capabilities: ...,
         serverPort: 0, // The port to start the test server on (serves your components).
-        idleTimeout: 60000, // Automatically disconnect after 1min by default.
+        idleTimeout: 60000, // Automatically disconnect after 1min of inactivity by default.
+        suiteTimeout: 600000, // Automatically disconnect after 10 minutes if the tests have not completed by default.
         viewport: {
           // Configure the screen size for any drivers started (defaults below).
           width: 800,
@@ -333,16 +341,16 @@ module.exports = function(markoCli) {
 
 # TODO
 
-* Don't write compiled templates to disk
-* Allow mocks for custom tags
-* File watching when running tests
-  * `marko test --watch`
-* Helper API for simulating DOM events
-* Plugin API for adding helpers to `context`
-* In-browser UI component viewer with file watching
-  * Drop down for inputs
-  * Editor for input data
-* In-browser project explorer (with links to run browser tests and view UI components)
-* Image snapshots
-* Testing in jsdom
-* Launching tests in multiple browsers (both headless and real browsers)
+- Don't write compiled templates to disk
+- Allow mocks for custom tags
+- File watching when running tests
+  - `marko test --watch`
+- Helper API for simulating DOM events
+- Plugin API for adding helpers to `context`
+- In-browser UI component viewer with file watching
+  - Drop down for inputs
+  - Editor for input data
+- In-browser project explorer (with links to run browser tests and view UI components)
+- Image snapshots
+- Testing in jsdom
+- Launching tests in multiple browsers (both headless and real browsers)

--- a/package-lock.json
+++ b/package-lock.json
@@ -156,20 +156,12 @@
 			"dev": true
 		},
 		"acorn-jsx": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
+			"integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^3.0.4"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-					"dev": true
-				}
+				"acorn": "^5.0.3"
 			}
 		},
 		"add-stream": {
@@ -179,21 +171,21 @@
 			"dev": true
 		},
 		"ajv": {
-			"version": "5.5.2",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
+			"integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
 			"dev": true,
 			"requires": {
-				"co": "^4.6.0",
-				"fast-deep-equal": "^1.0.0",
+				"fast-deep-equal": "^2.0.1",
 				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.3.0"
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.1"
 			}
 		},
 		"ajv-keywords": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+			"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
 			"dev": true
 		},
 		"align-text": {
@@ -260,9 +252,9 @@
 			}
 		},
 		"app-root-path": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
-			"integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.1.0.tgz",
+			"integrity": "sha1-mL9lmTJ+zqGZMJhm6BQDaP0uZGo=",
 			"dev": true
 		},
 		"aproba": {
@@ -1551,9 +1543,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000856",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000856.tgz",
-			"integrity": "sha512-x3mYcApHMQemyaHuH/RyqtKCGIYTgEA63fdi+VBvDz8xUSmRiVWTLeyKcoGQCGG6UPR9/+4qG4OKrTa6aSQRKg==",
+			"version": "1.0.30000865",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000865.tgz",
+			"integrity": "sha512-vs79o1mOSKRGv/1pSkp4EXgl4ZviWeYReXw60XfacPU64uQWZwJT6vZNmxRF9O+6zu71sJwMxLK5JXxbzuVrLw==",
 			"dev": true
 		},
 		"capture-stack-trace": {
@@ -1734,12 +1726,6 @@
 				"mkdirp": "~0.5.0"
 			}
 		},
-		"co": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-			"dev": true
-		},
 		"co-with-promise": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co-with-promise/-/co-with-promise-4.6.0.tgz",
@@ -1817,9 +1803,9 @@
 			"dev": true
 		},
 		"commander": {
-			"version": "2.15.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
+			"integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
 			"dev": true
 		},
 		"common-path-prefix": {
@@ -2800,6 +2786,16 @@
 				"clone": "^1.0.2"
 			}
 		},
+		"define-properties": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+			"dev": true,
+			"requires": {
+				"foreach": "^2.0.5",
+				"object-keys": "^1.0.8"
+			}
+		},
 		"define-property": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -2945,9 +2941,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.49",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.49.tgz",
-			"integrity": "sha1-ZROEsNgfB4qWY5srNpdRQbeRUAQ=",
+			"version": "1.3.52",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.52.tgz",
+			"integrity": "sha1-0tnxJwuko7lnuDHEDvcftNmrXOA=",
 			"dev": true
 		},
 		"elegant-spinner": {
@@ -2981,6 +2977,30 @@
 				"is-arrayish": "^0.2.1"
 			}
 		},
+		"es-abstract": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+			"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+			"dev": true,
+			"requires": {
+				"es-to-primitive": "^1.1.1",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.1",
+				"is-callable": "^1.1.3",
+				"is-regex": "^1.0.4"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"dev": true,
+			"requires": {
+				"is-callable": "^1.1.1",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.1"
+			}
+		},
 		"es6-error": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
@@ -2994,51 +3014,65 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "4.19.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
-			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.1.0.tgz",
+			"integrity": "sha512-DyH6JsoA1KzA5+OSWFjg56DFJT+sDLO0yokaPZ9qY0UEmYrPA1gEX/G1MnVkmRDsksG4H1foIVz2ZXXM3hHYvw==",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.3.0",
-				"babel-code-frame": "^6.22.0",
+				"ajv": "^6.5.0",
+				"babel-code-frame": "^6.26.0",
 				"chalk": "^2.1.0",
-				"concat-stream": "^1.6.0",
-				"cross-spawn": "^5.1.0",
+				"cross-spawn": "^6.0.5",
 				"debug": "^3.1.0",
 				"doctrine": "^2.1.0",
-				"eslint-scope": "^3.7.1",
+				"eslint-scope": "^4.0.0",
+				"eslint-utils": "^1.3.1",
 				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^3.5.4",
-				"esquery": "^1.0.0",
+				"espree": "^4.0.0",
+				"esquery": "^1.0.1",
 				"esutils": "^2.0.2",
 				"file-entry-cache": "^2.0.0",
 				"functional-red-black-tree": "^1.0.1",
 				"glob": "^7.1.2",
-				"globals": "^11.0.1",
+				"globals": "^11.7.0",
 				"ignore": "^3.3.3",
 				"imurmurhash": "^0.1.4",
-				"inquirer": "^3.0.6",
-				"is-resolvable": "^1.0.0",
-				"js-yaml": "^3.9.1",
+				"inquirer": "^5.2.0",
+				"is-resolvable": "^1.1.0",
+				"js-yaml": "^3.11.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.3.0",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.2",
+				"lodash": "^4.17.5",
+				"minimatch": "^3.0.4",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.8.2",
 				"path-is-inside": "^1.0.2",
 				"pluralize": "^7.0.0",
 				"progress": "^2.0.0",
-				"regexpp": "^1.0.1",
+				"regexpp": "^1.1.0",
 				"require-uncached": "^1.0.3",
-				"semver": "^5.3.0",
+				"semver": "^5.5.0",
+				"string.prototype.matchall": "^2.0.0",
 				"strip-ansi": "^4.0.0",
-				"strip-json-comments": "~2.0.1",
-				"table": "4.0.2",
-				"text-table": "~0.2.0"
+				"strip-json-comments": "^2.0.1",
+				"table": "^4.0.3",
+				"text-table": "^0.2.0"
 			},
 			"dependencies": {
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
 				"globals": {
 					"version": "11.7.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
@@ -3065,9 +3099,9 @@
 			}
 		},
 		"eslint-plugin-prettier": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.0.tgz",
-			"integrity": "sha512-floiaI4F7hRkTrFe8V2ItOK97QYrX75DjmdzmVITZoAP6Cn06oEDPQRsO6MlHEP/u2SxI3xQ52Kpjw6j5WGfeQ==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.2.tgz",
+			"integrity": "sha512-tGek5clmW5swrAx1mdPYM8oThrBE83ePh7LeseZHBWfHVGrHPhKn7Y5zgRMbU/9D5Td9K4CEmUPjGxA7iw98Og==",
 			"dev": true,
 			"requires": {
 				"fast-diff": "^1.1.1",
@@ -3075,14 +3109,20 @@
 			}
 		},
 		"eslint-scope": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+			"integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
 			"dev": true,
 			"requires": {
 				"esrecurse": "^4.1.0",
 				"estraverse": "^4.1.1"
 			}
+		},
+		"eslint-utils": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+			"integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+			"dev": true
 		},
 		"eslint-visitor-keys": {
 			"version": "1.0.0",
@@ -3103,25 +3143,25 @@
 			}
 		},
 		"espree": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-4.0.0.tgz",
+			"integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
 			"dev": true,
 			"requires": {
-				"acorn": "^5.5.0",
-				"acorn-jsx": "^3.0.0"
+				"acorn": "^5.6.0",
+				"acorn-jsx": "^4.1.1"
 			}
 		},
 		"esprima": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
 			"dev": true
 		},
 		"espurify": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.0.tgz",
-			"integrity": "sha512-jdkJG9jswjKCCDmEridNUuIQei9algr+o66ZZ19610ZoBsiWLRsQGNYS4HGez3Z/DsR0lhANGAqiwBUclPuNag==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.1.tgz",
+			"integrity": "sha512-ZDko6eY/o+D/gHCWyHTU85mKDgYcS4FJj7S+YD6WIInm7GQ6AnOjmcL4+buFV/JOztVLELi/7MmuGU5NHta0Mg==",
 			"dev": true,
 			"requires": {
 				"core-js": "^2.0.0"
@@ -3238,9 +3278,9 @@
 			}
 		},
 		"fast-deep-equal": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
 			"dev": true
 		},
 		"fast-diff": {
@@ -3357,6 +3397,12 @@
 			"requires": {
 				"for-in": "^1.0.1"
 			}
+		},
+		"foreach": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"dev": true
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
@@ -3919,6 +3965,12 @@
 				}
 			}
 		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
 		"function-name-support": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/function-name-support/-/function-name-support-0.2.0.tgz",
@@ -3979,9 +4031,9 @@
 			}
 		},
 		"get-caller-file": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
 			"dev": true
 		},
 		"get-own-enumerable-property-symbols": {
@@ -4451,6 +4503,15 @@
 				}
 			}
 		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
 		"has-ansi": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -4470,6 +4531,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
 			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+			"dev": true
+		},
+		"has-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
 			"dev": true
 		},
 		"has-unicode": {
@@ -4555,9 +4622,9 @@
 			}
 		},
 		"hosted-git-info": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-			"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
 			"dev": true
 		},
 		"hullabaloo-config-manager": {
@@ -4679,22 +4746,21 @@
 			"dev": true
 		},
 		"inquirer": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+			"integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^3.0.0",
 				"chalk": "^2.0.0",
 				"cli-cursor": "^2.1.0",
 				"cli-width": "^2.0.0",
-				"external-editor": "^2.0.4",
+				"external-editor": "^2.1.0",
 				"figures": "^2.0.0",
 				"lodash": "^4.3.0",
 				"mute-stream": "0.0.7",
 				"run-async": "^2.2.0",
-				"rx-lite": "^4.0.8",
-				"rx-lite-aggregates": "^4.0.8",
+				"rxjs": "^5.5.2",
 				"string-width": "^2.1.0",
 				"strip-ansi": "^4.0.0",
 				"through": "^2.3.6"
@@ -4760,6 +4826,12 @@
 				"builtin-modules": "^1.0.0"
 			}
 		},
+		"is-callable": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+			"dev": true
+		},
 		"is-ci": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
@@ -4777,6 +4849,12 @@
 			"requires": {
 				"kind-of": "^3.0.2"
 			}
+		},
+		"is-date-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
@@ -4906,23 +4984,6 @@
 				"symbol-observable": "^1.1.0"
 			}
 		},
-		"is-odd": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-			"dev": true,
-			"requires": {
-				"is-number": "^4.0.0"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-					"dev": true
-				}
-			}
-		},
 		"is-path-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
@@ -4994,6 +5055,15 @@
 			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
 			"dev": true
 		},
+		"is-regex": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.1"
+			}
+		},
 		"is-regexp": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
@@ -5022,6 +5092,12 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
 			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+			"dev": true
+		},
+		"is-symbol": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
 			"dev": true
 		},
 		"is-text-path": {
@@ -5085,15 +5161,15 @@
 			"dev": true
 		},
 		"jest-validate": {
-			"version": "23.0.1",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.0.1.tgz",
-			"integrity": "sha1-zZ8BqJ0mu4hfEqhmdxXpyGWldU8=",
+			"version": "23.4.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.4.0.tgz",
+			"integrity": "sha1-2W7t4B7wOskJwAnpyORVGX1IwgE=",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
 				"jest-get-type": "^22.1.0",
 				"leven": "^2.1.0",
-				"pretty-format": "^23.0.1"
+				"pretty-format": "^23.2.0"
 			}
 		},
 		"js-string-escape": {
@@ -5131,9 +5207,9 @@
 			"dev": true
 		},
 		"json-schema-traverse": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true
 		},
 		"json-stable-stringify-without-jsonify": {
@@ -5282,6 +5358,28 @@
 					"requires": {
 						"is-glob": "^3.1.0",
 						"path-dirname": "^1.0.0"
+					}
+				},
+				"inquirer": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+					"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+					"dev": true,
+					"requires": {
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.0",
+						"cli-cursor": "^2.1.0",
+						"cli-width": "^2.0.0",
+						"external-editor": "^2.0.4",
+						"figures": "^2.0.0",
+						"lodash": "^4.3.0",
+						"mute-stream": "0.0.7",
+						"run-async": "^2.2.0",
+						"rx-lite": "^4.0.8",
+						"rx-lite-aggregates": "^4.0.8",
+						"string-width": "^2.1.0",
+						"strip-ansi": "^4.0.0",
+						"through": "^2.3.6"
 					}
 				},
 				"is-extglob": {
@@ -5813,6 +5911,15 @@
 						"chalk": "^1.0.0"
 					}
 				},
+				"rxjs": {
+					"version": "6.2.2",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.2.tgz",
+					"integrity": "sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==",
+					"dev": true,
+					"requires": {
+						"tslib": "^1.9.0"
+					}
+				},
 				"slice-ansi": {
 					"version": "0.0.4",
 					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
@@ -6203,12 +6310,12 @@
 			"dev": true
 		},
 		"loose-envify": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
 			"dev": true,
 			"requires": {
-				"js-tokens": "^3.0.0"
+				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
 		"loud-rejection": {
@@ -6554,9 +6661,9 @@
 			"optional": true
 		},
 		"nanomatch": {
-			"version": "1.2.9",
-			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+			"version": "1.2.13",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
 			"dev": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
@@ -6564,7 +6671,6 @@
 				"define-property": "^2.0.2",
 				"extend-shallow": "^3.0.2",
 				"fragment-cache": "^0.2.1",
-				"is-odd": "^2.0.0",
 				"is-windows": "^1.0.2",
 				"kind-of": "^6.0.2",
 				"object.pick": "^1.3.0",
@@ -6597,6 +6703,12 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
+		},
+		"nice-try": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
+			"integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
 			"dev": true
 		},
 		"normalize-package-data": {
@@ -6694,6 +6806,12 @@
 					}
 				}
 			}
+		},
+		"object-keys": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+			"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+			"dev": true
 		},
 		"object-visit": {
 			"version": "1.0.1",
@@ -7146,9 +7264,9 @@
 			}
 		},
 		"please-upgrade-node": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.0.2.tgz",
-			"integrity": "sha512-bslfSeW+ksUbB/sYZeEdKFyTG4YWU9YKRvqfSRvZKE675khAuBUPqV5RUwJZaGuWmVQLweK45Q+lPHFVnSlSug==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz",
+			"integrity": "sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==",
 			"dev": true,
 			"requires": {
 				"semver-compare": "^1.0.0"
@@ -7194,15 +7312,15 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "1.13.5",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.5.tgz",
-			"integrity": "sha512-4M90mfvLz6yRf2Dhzd+xPIE6b4xkI8nHMJhsSm9IlfG17g6wujrrm7+H1X8x52tC4cSNm6HmuhCUSNe6Hd5wfw==",
+			"version": "1.13.7",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.7.tgz",
+			"integrity": "sha512-KIU72UmYPGk4MujZGYMFwinB7lOf2LsDNGSOC8ufevsrPLISrZbNJlWstRi3m0AMuszbH+EFSQ/r6w56RSPK6w==",
 			"dev": true
 		},
 		"pretty-format": {
-			"version": "23.0.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
-			"integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
+			"integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
 			"dev": true,
 			"requires": {
 				"ansi-regex": "^3.0.0",
@@ -7256,6 +7374,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
+		},
+		"punycode": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
 		"q": {
@@ -7433,6 +7557,15 @@
 			"requires": {
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
+			}
+		},
+		"regexp.prototype.flags": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
+			"integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2"
 			}
 		},
 		"regexpp": {
@@ -7639,12 +7772,20 @@
 			}
 		},
 		"rxjs": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.1.tgz",
-			"integrity": "sha512-OwMxHxmnmHTUpgO+V7dZChf3Tixf4ih95cmXjzzadULziVl/FKhHScGLj4goEw9weePVOH2Q0+GcCBUhKCZc/g==",
+			"version": "5.5.11",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.11.tgz",
+			"integrity": "sha512-3bjO7UwWfA2CV7lmwYMBzj4fQ6Cq+ftHc2MvUe+WMS7wcdJ1LosDWmdjPQanYp2dBRj572p7PeU81JUxHKOcBA==",
 			"dev": true,
 			"requires": {
-				"tslib": "^1.9.0"
+				"symbol-observable": "1.0.1"
+			},
+			"dependencies": {
+				"symbol-observable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+					"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+					"dev": true
+				}
 			}
 		},
 		"safe-buffer": {
@@ -8061,6 +8202,19 @@
 				"strip-ansi": "^4.0.0"
 			}
 		},
+		"string.prototype.matchall": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-2.0.0.tgz",
+			"integrity": "sha512-WoZ+B2ypng1dp4iFLF2kmZlwwlE19gmjgKuhL1FJfDgCREWb3ye3SDVHSzLH6bxfnvYmkCxbzkmWcQZHA4P//Q==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.10.0",
+				"function-bind": "^1.1.1",
+				"has-symbols": "^1.0.0",
+				"regexp.prototype.flags": "^1.2.0"
+			}
+		},
 		"string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -8192,13 +8346,13 @@
 			"dev": true
 		},
 		"table": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
+			"integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.2.3",
-				"ajv-keywords": "^2.1.0",
+				"ajv": "^6.0.1",
+				"ajv-keywords": "^3.0.0",
 				"chalk": "^2.1.0",
 				"lodash": "^4.17.4",
 				"slice-ansi": "1.0.0",
@@ -8232,9 +8386,9 @@
 					"dev": true
 				},
 				"uuid": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-					"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+					"version": "3.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
 					"dev": true
 				}
 			}
@@ -8374,9 +8528,9 @@
 			"dev": true
 		},
 		"tslib": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.2.tgz",
-			"integrity": "sha512-AVP5Xol3WivEr7hnssHDsaM+lVrVXWUvd1cfXTRkTj80b//6g2wIFEH6hZG0muGZRnHGrfttpdzRk3YlBkWjKw==",
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
 			"dev": true
 		},
 		"type-check": {
@@ -8572,6 +8726,15 @@
 				"xdg-basedir": "^3.0.0"
 			}
 		},
+		"uri-js": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
 		"urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
@@ -8588,21 +8751,10 @@
 			}
 		},
 		"use": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
-			"dev": true,
-			"requires": {
-				"kind-of": "^6.0.2"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
-				}
-			}
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+			"dev": true
 		},
 		"user-home": {
 			"version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "eslint": "^4.19.1",
+    "eslint": "^5.1.0",
     "eslint-config-prettier": "^2.9.0",
-    "eslint-plugin-prettier": "^2.6.0",
+    "eslint-plugin-prettier": "^2.6.2",
     "husky": "^0.14.3",
     "lerna": "^2.11.0",
-    "lint-staged": "^7.1.2",
-    "prettier": "^1.12.1"
+    "lint-staged": "^7.2.0",
+    "prettier": "^1.13.7"
   },
   "lint-staged": {
     "*.{json,css,less,md}": [
@@ -27,8 +27,8 @@
     ]
   },
   "scripts": {
-    "build": "for pkg in ./packages/*; do (cd $pkg && rm -rf ./dist && babel ./src --out-dir ./dist); done",
-    "clean": "lerna clean && rm -rf ./packages/*/dist",
+    "build": "for pkg in ./packages/*; do (cd $pkg && rm -rf ./dist && babel ./src --out-dir ./dist --copy-files); done",
+    "clean": "lerna clean && rm -rf ./packages/*/{dist,package-lock.json} ./package-lock.json ./node_modules",
     "format": "prettier \"packages/**/*.{json,css,less,md,js}\" \"*.{json,md,js}\" --write",
     "lint": "eslint -f visualstudio packages/",
     "postinstall": "lerna bootstrap --hoist",

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,0 +1,29 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"complain": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/complain/-/complain-1.3.0.tgz",
+			"integrity": "sha512-PA9uGpaS4BXKrhFx3rl2nZMWySnGoW1pWf+dpBqNdDx3uR6PA0EPxjD17H9OxvW5w/bODBSziQ516Guf59rW+w==",
+			"requires": {
+				"error-stack-parser": "^2.0.1"
+			},
+			"dependencies": {
+				"error-stack-parser": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.2.tgz",
+					"integrity": "sha512-E1fPutRDdIj/hohG0UpT5mayXNCxXP9d+snxFsPU9X0XgccOumKraa3juDMwTUyi7+Bu5+mCGagjg4IYeNbOdw==",
+					"requires": {
+						"stackframe": "^1.0.4"
+					}
+				},
+				"stackframe": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
+					"integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw=="
+				}
+			}
+		}
+	}
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/marko-js/marko-cli/issues",
   "dependencies": {
-    "@marko/compile": "^3.1.0",
+    "@marko/compile": "^3.1.6",
     "@marko/create": "^3.1.6",
     "@marko/test": "^3.1.6",
     "app-root-dir": "^1.0.2",
@@ -16,6 +16,7 @@
     "babel-runtime": "^6.26.0",
     "chalk": "^2.4.1",
     "complain": "^1.2.0",
+    "parse-node-args": "1.1.1",
     "resolve-from": "^4.0.0",
     "update-notifier": "^2.5.0"
   },

--- a/packages/cli/src/commands/test/parse.js
+++ b/packages/cli/src/commands/test/parse.js
@@ -1,5 +1,7 @@
+const parseNodeArgs = require("parse-node-args");
 module.exports = function parse(argv) {
-  var options = require("argly")
+  const { cliArgs, nodeArgs } = parseNodeArgs(argv);
+  const options = require("argly")
     .createParser({
       "--help": {
         type: "string",
@@ -53,9 +55,10 @@ module.exports = function parse(argv) {
       console.error(err);
       process.exit(1);
     })
-    .parse(argv);
+    .parse(cliArgs);
 
   options.patterns = options.files;
+  options.nodeArgs = nodeArgs;
   delete options.files;
 
   return options;

--- a/packages/compile/package.json
+++ b/packages/compile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@marko/compile",
   "description": "Compile Marko files",
-  "version": "3.1.0",
+  "version": "3.1.6",
   "bugs": "https://github.com/marko-js/marko-cli/issues",
   "dependencies": {
     "babel-runtime": "^6.26.0",

--- a/packages/prebuild/package-lock.json
+++ b/packages/prebuild/package-lock.json
@@ -226,9 +226,9 @@
 					}
 				},
 				"complain": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/complain/-/complain-1.2.0.tgz",
-					"integrity": "sha512-aP/MxFoYYVUZ8Xdih1vyaTSRiD99XLnlCloNre/UjFQFJkZ6YuMbGksi0jfxKeFOdlzm/6eE01vpJc99HiN/Mg==",
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/complain/-/complain-1.3.0.tgz",
+					"integrity": "sha512-PA9uGpaS4BXKrhFx3rl2nZMWySnGoW1pWf+dpBqNdDx3uR6PA0EPxjD17H9OxvW5w/bODBSziQ516Guf59rW+w==",
 					"requires": {
 						"error-stack-parser": "^2.0.1"
 					}
@@ -323,9 +323,9 @@
 					"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
 				},
 				"escodegen": {
-					"version": "1.10.0",
-					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.10.0.tgz",
-					"integrity": "sha512-fjUOf8johsv23WuIKdNQU4P9t9jhQ4Qzx6pC2uW890OloK3Zs1ZAoCNpg/2larNF501jLl3UNy0kIRcF6VI22g==",
+					"version": "1.11.0",
+					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
+					"integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
 					"requires": {
 						"esprima": "^3.1.3",
 						"estraverse": "^4.2.0",
@@ -348,9 +348,9 @@
 					}
 				},
 				"esprima": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 				},
 				"estraverse": {
 					"version": "4.2.0",
@@ -597,15 +597,15 @@
 					"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
 				},
 				"marko": {
-					"version": "4.11.1",
-					"resolved": "https://registry.npmjs.org/marko/-/marko-4.11.1.tgz",
-					"integrity": "sha512-IjnvbqL2FzuR1/8JOqu0Dq8lkX56MS7VWE44d9/UV3aFIfA0mr1my8MoGPYqaFoUnW+KLkqQMEJOfGrUXEgfaw==",
+					"version": "4.12.1",
+					"resolved": "https://registry.npmjs.org/marko/-/marko-4.12.1.tgz",
+					"integrity": "sha512-zJYlR+N3OM2bqjTgHUe1WhMjCjxDX1X6IqOSexv1ePoCbFDp4Gs15Hm7IaoKD8nBJmDnhjMIHn4SdTlp0Rc42Q==",
 					"requires": {
 						"app-module-path": "^2.2.0",
 						"argly": "^1.0.0",
 						"browser-refresh-client": "^1.0.0",
 						"char-props": "~0.1.5",
-						"complain": "^1.2.0",
+						"complain": "^1.3.0",
 						"deresolve": "^1.1.2",
 						"escodegen": "^1.8.1",
 						"esprima": "^4.0.0",
@@ -1115,9 +1115,9 @@
 					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 				},
 				"uuid": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-					"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+					"version": "3.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 				},
 				"warp10": {
 					"version": "1.3.6",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -13,7 +13,7 @@
     "cheerio": "^1.0.0-rc.2",
     "child-process-promise": "^2.2.1",
     "chromedriver": "^2.40.0",
-    "complain": "^1.2.0",
+    "complain": "^1.3.0",
     "delay": "^3.0.0",
     "engine.io": "^3.2.0",
     "engine.io-client": "^3.2.1",
@@ -21,18 +21,19 @@
     "get-port": "^3.2.0",
     "is-port-free": "^1.0.7",
     "lasso": "^3.2.0",
-    "lasso-istanbul-instrument-transform": "0.0.4",
+    "lasso-istanbul-instrument-transform": "2.0.0",
     "lasso-marko": "^2.4.2",
     "lasso-require": "^3.4.10",
-    "marko": "^4.11.1",
+    "marko": "^4.12.0",
     "mocha": "^5.2.0",
     "mz": "^2.7.0",
-    "p-event": "^2.0.0",
+    "node-fetch": "2.1.2",
+    "p-event": "^2.1.0",
     "raptor-renderer": "^1.5.0",
     "resolve-from": "^4.0.0",
     "strip-ansi": "^4.0.0",
     "wdio-chromedriver-service": "^0.1.3",
-    "webdriverio": "^4.13.0"
+    "webdriverio": "^4.13.1"
   },
   "files": [
     "dist"

--- a/packages/test/src/index.js
+++ b/packages/test/src/index.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const complain = require("complain");
 const loadTests = require("./util/loadTests");
 const serverTestsRunner = require("./util/server-tests-runner");
@@ -5,6 +6,7 @@ const browserTestsRunner = require("./util/browser-tests-runner");
 
 exports.run = function(options) {
   options.dir = options.dir || process.cwd();
+  options.packageName = require(path.join(options.dir, "package.json")).name;
 
   if (options.server == null) {
     if (options.browser == null) {

--- a/packages/test/src/util/browser-tests-runner/driver.js
+++ b/packages/test/src/util/browser-tests-runner/driver.js
@@ -1,6 +1,7 @@
 const chalk = require("chalk");
 const delay = require("delay");
 const webdriver = require("webdriverio");
+const wdioDefaults = require("./util/wdio-defaults");
 const ensureCalled = require("./util/ensure-called");
 const { env } = process;
 const {
@@ -15,21 +16,26 @@ const DEFAULT_VIEWPORT = {
   width: 800,
   height: 600
 };
+const DEFAULT_TIMEOUTS = {
+  idle: 240000,
+  suite: 600000
+};
 
 exports.start = async (href, options) => {
   let exitCode = 1;
   const {
     noExit,
+    packageName,
     mochaOptions,
     wdioOptions: { launcher, ...wdioOptions }
   } = options;
   const { capabilities } = wdioOptions;
   wdioOptions.baseUrl = `${href}?${encodeURIComponent(
-    JSON.stringify({ mochaOptions })
+    JSON.stringify({ mochaOptions, packageName })
   )}`;
 
   await launcher.onPrepare(wdioOptions, capabilities);
-  await delay(500); // Give the launcher (esp the local chrome launcher) some time to init.
+  await delay(wdioDefaults.startDelay); // Give the launcher some time to init.
   ensureCalled(() =>
     Promise.race([launcher.onComplete(exitCode, wdioOptions), delay(3000)])
   );
@@ -42,7 +48,10 @@ exports.start = async (href, options) => {
       ensureCalled(() => driver && driver.end());
 
       for (const capability of capabilities) {
-        const { testName } = (driver = connect(wdioOptions, capability));
+        const { testName } = (driver = connect(
+          wdioOptions,
+          capability
+        ));
         results[testName] = false;
 
         console.log(`\n${format(testName, "starting...")}\n`);
@@ -103,14 +112,16 @@ exports.start = async (href, options) => {
  * resolves to a function which will run tests for that driver.
  */
 function connect({ viewport = DEFAULT_VIEWPORT, ...options }, capability) {
+  const {
+    suiteTimeout = DEFAULT_TIMEOUTS.suite,
+    idleTimeout = DEFAULT_TIMEOUTS.idle
+  } = options;
   const browser = capability.browser || capability.browserName;
   const version =
     capability.browser_version || capability.platformVersion || "latest";
   const platform =
     (capability.os && `${capability.os} ${capability.os_version}`) ||
     capability.platformName;
-  const timeout = options.idleTimeout || 60000;
-
   const driver = webdriver
     .remote({
       ...options,
@@ -122,15 +133,45 @@ function connect({ viewport = DEFAULT_VIEWPORT, ...options }, capability) {
       }
     })
     .init()
-    .url("")
-    .timeouts("script", timeout)
-    .timeouts("implicit", timeout)
-    .timeouts("page load", timeout)
+    .timeouts("script", idleTimeout)
+    .timeouts("implicit", idleTimeout)
+    .timeouts("page load", idleTimeout)
     .setViewportSize(viewport)
+    .url("")
     .then(() => () => {
-      return driver.executeAsync(function(done) {
-        window.__run_tests__(done);
-      });
+      const endTime = Date.now() + suiteTimeout;
+      const execInterval = Math.min(idleTimeout, DEFAULT_TIMEOUTS.idle) * 0.8;
+      // Some services force a max timeout for async scripts.
+      // Below we restart the async script the waits for the tests to be done every 60 seconds.
+      // The tests are 'complete' once the global '__test_result__' is set on the window.
+      return (function getResults() {
+        if (endTime < Date.now()) {
+          throw new Error(
+            'marko-cli: Test suite timed out, use "wdioOptions.suiteTimeout" to increase the delay (default 10 mins).'
+          );
+        }
+
+        return driver
+          .executeAsync(function(interval, done) {
+            if (window.__test_result__) done(window.__test_result__);
+            else {
+              var timeout = setTimeout(function() {
+                delete window.__test_result__;
+                done();
+              }, interval);
+              Object.defineProperty(window, "__test_result__", {
+                configurable: true,
+                set: function(result) {
+                  clearTimeout(timeout);
+                  done(result);
+                }
+              });
+            }
+          }, execInterval)
+          .then(result => {
+            return result.value ? result : getResults();
+          });
+      })();
     });
 
   driver.testName = `${browser}@${version}${platform ? ` on ${platform}` : ""}`;

--- a/packages/test/src/util/browser-tests-runner/server.js
+++ b/packages/test/src/util/browser-tests-runner/server.js
@@ -4,6 +4,7 @@ require("marko/express");
 const pEvent = require("p-event");
 const express = require("express");
 const engine = require("engine.io");
+const fetch = require("node-fetch");
 const wdioDefaults = require("./util/wdio-defaults");
 const ensureCalled = require("./util/ensure-called");
 const defaultPageTemplate = require("./template.marko");
@@ -52,6 +53,10 @@ exports.start = async (templateData, options) => {
     console.log(`Server running at http://localhost:${port}`);
   }
 
+  // Warmup lasso cache.
+  const href = `http://localhost:${port}`;
+  await (await fetch(href, { method: "GET" })).text();
+
   // Stream logs from client via websocket.
   wss.on("connection", socket =>
     socket.on("message", msg => {
@@ -69,7 +74,5 @@ exports.start = async (templateData, options) => {
     return pEvent(server, "close");
   });
 
-  return {
-    href: `http://localhost:${port}`
-  };
+  return { href };
 };

--- a/packages/test/src/util/browser-tests-runner/util/wdio-defaults.js
+++ b/packages/test/src/util/browser-tests-runner/util/wdio-defaults.js
@@ -5,9 +5,11 @@ const resolveFrom = require("resolve-from");
 let name;
 let ports;
 let required;
+let startDelay;
 let defaults;
 
 if (env.BROWSERSTACK_USER) {
+  startDelay = 1000;
   name = "browserstack";
   ports = [
     22,
@@ -60,9 +62,11 @@ if (env.BROWSERSTACK_USER) {
   defaults = {
     user: env.BROWSERSTACK_USER,
     key: env.BROWSERSTACK_ACCESS_KEY,
+    browserstackLocalForcedStop: true,
     browserstackLocal: true
   };
 } else if (env.SAUCE_USERNAME) {
+  startDelay = 0;
   name = "sauce";
   ports = [
     80,
@@ -130,6 +134,7 @@ if (env.BROWSERSTACK_USER) {
     sauceConnect: true
   };
 } else if (env.TB_KEY) {
+  startDelay = 0;
   name = "testingbot";
   ports = [4445, 4444];
   defaults = {
@@ -138,6 +143,7 @@ if (env.BROWSERSTACK_USER) {
     tbTunnel: true
   };
 } else {
+  startDelay = 500;
   name = "chromedriver";
   required = {
     capabilities: [{ browserName: "chrome" }]
@@ -153,6 +159,7 @@ module.exports = {
   ports,
   required,
   defaults,
+  startDelay,
   isValidPort(port) {
     return !ports || ports.indexOf(port) !== -1;
   },

--- a/packages/test/src/util/server-tests-runner/index.js
+++ b/packages/test/src/util/server-tests-runner/index.js
@@ -33,7 +33,7 @@ function convertMochaConfigToArgs(config) {
 }
 
 exports.run = function(allTests, options) {
-  let { dir, cliRoot, mochaOptions } = options;
+  let { dir, cliRoot, mochaOptions, nodeArgs } = options;
   var filteredTests = allTests.filter(test => {
     return test.env === "server" || test.env === "both";
   });
@@ -60,7 +60,7 @@ exports.run = function(allTests, options) {
     const convertedMochaArgs = convertMochaConfigToArgs(mochaOptions);
 
     if (convertedMochaArgs.length) {
-      spawnArgs = spawnArgs.concat(convertedMochaArgs);
+      spawnArgs = spawnArgs.concat(convertedMochaArgs).concat(nodeArgs);
     }
   }
 
@@ -72,8 +72,5 @@ exports.run = function(allTests, options) {
     cwd: dir,
     env,
     stdio: "inherit"
-  }).catch(err => {
-    console.error("Error spawning mocha from marko-cli", err);
-    process.exit(1);
-  });
+  }).catch(() => process.exit(1));
 };


### PR DESCRIPTION
## `--browser` test changes:
* Improve test resilience and timeout handling (especially with browserstack).
    * Prevents timeouts by manually polling webdriver command until completion.
    * Added delay overrides for launchers (browser stack needed a 10s delay).
    * Warmup lasso cache before calling webdriver to decrease the total time the driver is waiting.
* Automatically re-run tests when refreshing in `no-exit` mode.
* Format stack traces to point to the proper locations in nodejs.

## `--server` test changes:
* Node args are now forwarded, allowing things like '--inspect' to pass through.

## both:
* Added new suiteTimeout option.