### PR TITLE
Local chrome driver improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ Run only server tests:
 marko test ./src/components/**/test*server.js --server
 ```
 
+Keep server open after the tests finish and disable headless mode for browser tests:
+
+```bash
+marko test --debug
+```
+
 All node options are forwarded to the mocha process for server testing, allowing the following:
 
 ```bash
@@ -352,5 +358,3 @@ module.exports = function(markoCli) {
   - Editor for input data
 - In-browser project explorer (with links to run browser tests and view UI components)
 - Image snapshots
-- Testing in jsdom
-- Launching tests in multiple browsers (both headless and real browsers)

--- a/packages/cli/src/commands/test/parse.js
+++ b/packages/cli/src/commands/test/parse.js
@@ -11,9 +11,10 @@ module.exports = function parse(argv) {
         type: "boolean",
         description: "Run only server tests"
       },
-      "--no-exit": {
+      "--debug": {
         type: "boolean",
-        description: "Do not shutdown the test server"
+        description:
+          "Does not shutdown the test server and disables headless mode for browser tests"
       },
       "--browser": {
         type: "boolean",

--- a/packages/test/src/util/browser-tests-runner/driver.js
+++ b/packages/test/src/util/browser-tests-runner/driver.js
@@ -24,7 +24,7 @@ const DEFAULT_TIMEOUTS = {
 exports.start = async (href, options) => {
   let exitCode = 1;
   const {
-    noExit,
+    debug,
     packageName,
     mochaOptions,
     wdioOptions: { launcher, ...wdioOptions }
@@ -70,7 +70,7 @@ exports.start = async (href, options) => {
           console.error(error);
         } finally {
           if (await isAlive(driver)) {
-            if (noExit) {
+            if (debug) {
               // Wait for the driver to die by pinging it every 3 seconds.
               do {
                 await delay(3000);

--- a/packages/test/src/util/browser-tests-runner/index.js
+++ b/packages/test/src/util/browser-tests-runner/index.js
@@ -19,6 +19,15 @@ exports.run = async (tests, options) => {
     launcher: wdioDefaults.getLauncher(options.dir)
   };
 
+  if (wdioDefaults.name === "chromedriver") {
+    const args = options.wdioOptions.capabilities[0].chromeOptions.args;
+
+    // Run chromedriver in headless mode unless running with debug option.
+    if (!options.debug) {
+      args.push("headless", "disable-gpu");
+    }
+  }
+
   const bundler = await createBundler(tests, options);
   const server = await startServer(bundler, options);
   const driver = await startDriver(server.href, options);

--- a/packages/test/src/util/browser-tests-runner/server.js
+++ b/packages/test/src/util/browser-tests-runner/server.js
@@ -49,7 +49,7 @@ exports.start = async (templateData, options) => {
     );
   }
 
-  if (options.noExit) {
+  if (options.debug) {
     console.log(`Server running at http://localhost:${port}`);
   }
 

--- a/packages/test/src/util/browser-tests-runner/util/wdio-defaults.js
+++ b/packages/test/src/util/browser-tests-runner/util/wdio-defaults.js
@@ -146,7 +146,18 @@ if (env.BROWSERSTACK_USER) {
   startDelay = 500;
   name = "chromedriver";
   required = {
-    capabilities: [{ browserName: "chrome" }]
+    capabilities: [
+      {
+        browserName: "chrome",
+        chromeOptions: {
+          args: [
+            "no-sandbox",
+            "disable-dev-shm-usage",
+            "disable-setuid-sandbox"
+          ]
+        }
+      }
+    ]
   };
   defaults = {
     path: "/",


### PR DESCRIPTION
Add default chrome driver options for CI usage and run chrome headless by default.

Exposes a `--debug` option which replaces the `--no-exit` option.
`--debug` keeps the server alive, while also disabling the headless mode in local browser tests.